### PR TITLE
fix action input key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   aws_key_id:
     description: 'aws key id'
     required: true
-  aws_secret_access-key:
+  aws_secret_access_key:
     description: 'aws secret access key'
     required: true
   aws_bucket:


### PR DESCRIPTION
When running this action, I ended up running into an issue:

```
##[warning]Unexpected input 'aws_secret_access_key', valid inputs are ['aws_key_id', 'aws_secret_access-key', 'aws_bucket', 'source_dir']
```

Looking at the docs and the code, the correct value for the secret access key is all underscores.