### PR TITLE
Upload to a specific directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,15 @@ jobs:
 
 The following settings must be passed as environment variables as shown in the example. Sensitive information, especially `aws_key_id` and `aws_secret_access_key`, should be [set as encrypted secrets](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables) — otherwise, they'll be public to anyone browsing your repository's source code
 
-| name                    | description                                                                                                                           |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `aws_key_id`            | (Required) Your AWS Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html)        |
+| name                    | description                                                  |
+| ----------------------- | ------------------------------------------------------------ |
+| `aws_key_id`            | (Required) Your AWS Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) |
 | `aws_secret_access_key` | (Required) Your AWS Secret Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) |
-| `aws_bucket`            | (Required) The name of the bucket you're upload to.                                                                                   |
-| `source_dir`            | (Required) The local directory (or file) you wish to upload to S3.                                                                    |
+| `aws_bucket`            | (Required) The name of the bucket you're upload to.          |
+| `source_dir`            | (Required) The local directory (or file) you wish to upload to S3. |
+| `destination_dir`       | (Optional) The destination directory in S3<br />If this field is excluded a [shortid](https://github.com/dylang/shortid) will be generated |
+
+> To upload to the root directory, set `destination_dir` to ""
 
 ## Action outputs
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   source_dir:
     required: true
     description: 'directory to upload'
+  destination_dir:
+    required: false
+    description: 'destination directory for upload'
 outputs:
   object_key:
     description: 'object key'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2414,12 +2414,15 @@ const BUCKET = core.getInput('aws_bucket', {
 const SOURCE_DIR = core.getInput('source_dir', {
   required: true
 });
+const DESTINATION_DIR = core.getInput('destination_dir', {
+  required: false
+})
 
 const s3 = new S3({
   accessKeyId: AWS_KEY_ID,
   secretAccessKey: SECRET_ACCESS_KEY
 });
-const objKey = shortid();
+const objKey = DESTINATION_DIR !== undefined ? DESTINATION_DIR : `${shortid()}/`;
 const paths = klawSync(SOURCE_DIR, {
   nodir: true
 });
@@ -2437,7 +2440,7 @@ function upload(params) {
 function run() {
   return Promise.all(
     paths.map(p => {
-      const Key = p.path.replace(path.join(process.cwd(), SOURCE_DIR), objKey);
+      const Key = p.path.replace(path.join(process.cwd(), SOURCE_DIR, '/'), objKey);
       const fileStream = fs.createReadStream(p.path);
       const params = {
         Bucket: BUCKET,

--- a/index.js
+++ b/index.js
@@ -18,12 +18,15 @@ const BUCKET = core.getInput('aws_bucket', {
 const SOURCE_DIR = core.getInput('source_dir', {
   required: true
 });
+const DESTINATION_DIR = core.getInput('destination_dir', {
+  required: false
+})
 
 const s3 = new S3({
   accessKeyId: AWS_KEY_ID,
   secretAccessKey: SECRET_ACCESS_KEY
 });
-const objKey = shortid();
+const objKey = DESTINATION_DIR !== undefined ? DESTINATION_DIR : `${shortid()}/`;
 const paths = klawSync(SOURCE_DIR, {
   nodir: true
 });
@@ -41,7 +44,7 @@ function upload(params) {
 function run() {
   return Promise.all(
     paths.map(p => {
-      const Key = p.path.replace(path.join(process.cwd(), SOURCE_DIR), objKey);
+      const Key = p.path.replace(path.join(process.cwd(), SOURCE_DIR, '/'), objKey);
       const fileStream = fs.createReadStream(p.path);
       const params = {
         Bucket: BUCKET,


### PR DESCRIPTION
Closes #2 

- Added destination dir input
  - if it is left out, it will fall back on shortid to provide a key
  - this will allow all current usage of the action w/ shortid keys to be uninterrupted 
- Updated Readme
- Built latest package
- Tested locally and on my fork