### PR TITLE
fix(Windows): wrong key / path destination

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,12 +47,16 @@ function run() {
   return Promise.all(
     paths.map(p => {
       const fileStream = fs.createReadStream(p.path);
-      const bucketPath = path.join(destinationDir, path.relative(sourceDir, p.path));
+      const filePath = path.join(destinationDir, path.relative(sourceDir, p.path));
+      
+      // make file path to s3 key using posix seperator
+      const key = filePath.split(path.sep).join(path.posix.sep);
+
       const params = {
         Bucket: BUCKET,
         ACL: 'public-read',
         Body: fileStream,
-        Key: bucketPath,
+        Key: key,
         ContentType: lookup(p.path) || 'text/plain'
       };
       return upload(params);


### PR DESCRIPTION
The bucketPath was used as key which is only workable for unix based system, under the windows ci host the remote key is created with the wrong path-seperator '\\' which does not reflect a sub-directory.