### PR TITLE
Reject promise and return on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,14 @@ const paths = klawSync(SOURCE_DIR, {
 });
 
 function upload(params) {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     s3.upload(params, (err, data) => {
-      if (err) core.error(err);
+      if (err) {
+        core.error(err);
+        reject(err)
+        return
+      }
+
       core.info(`uploaded - ${data.Key}`);
       core.info(`located - ${data.Location}`);
       resolve(data.Location);


### PR DESCRIPTION
## Problem

When there is an error in the upload process, two different errors are printed to console with the second being a non-obvious code error. This can be confusing for the person troubleshooting.

Example:

```
Error: AccessControlListNotSupported: The bucket does not allow ACLs
/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:11396
            throw err;
            ^

Error [TypeError]: Cannot read properties of undefined (reading 'Key')
    at ManagedUpload.callback (/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:28879:36)
    at Response.finishSinglePart (/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:13280:28)
    at Request.<anonymous> (/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:11732:18)
    at Request.callListeners (/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:13445:20)
    at Request.emit (/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:13417:10)
    at Request.emit (/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:12051:14)
    at Request.transition (/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:11387:10)
    at AcceptorStateMachine.runTo (/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:17191:12)
    at /home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:17203:10
    at Request.<anonymous> (/home/runner/work/_actions/shallwefootball/upload-s3-action/v1.2.0/dist/index.js:11403:9) {
  code: 'TypeError',
  time: 2022-12-14T20:02:01.354Z
}
```

The second error (`TypeError`) is thrown when we attempt to log out a success message when `data` is undefined.

```js
core.info(`uploaded - ${data.Key}`);
```

## Solution

Reject the promise and return from the callback.